### PR TITLE
feat(TextChannel): RateLimitPerUser (#2811)

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -286,6 +286,7 @@ class GuildChannel extends Channel {
    * Lock the permissions of the channel to what the parent's permissions are
    * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
    * Permission overwrites for the channel
+   * @property {number} [rateLimitPerUser] The ratelimit per user for the channel
    */
 
   /**
@@ -323,6 +324,7 @@ class GuildChannel extends Channel {
         user_limit: typeof data.userLimit !== 'undefined' ? data.userLimit : this.userLimit,
         parent_id: data.parentID,
         lock_permissions: data.lockPermissions,
+        rate_limit_per_user: data.rateLimitPerUser,
         permission_overwrites,
       },
       reason,

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -44,12 +44,28 @@ class TextChannel extends GuildChannel {
     this.lastMessageID = data.last_message_id;
 
     /**
+     * The ratelimit per user for this channel
+     * @type {number}
+     */
+    this.rateLimitPerUser = data.rate_limit_per_user || 0;
+
+    /**
      * The timestamp when the last pinned message was pinned, if there was one
      * @type {?number}
      */
     this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
 
     if (data.messages) for (const message of data.messages) this.messages.add(message);
+  }
+
+  /**
+   * Sets the rate limit per user for this channel.
+   * @param {number} rateLimitPerUser The new ratelimit
+   * @param {string} [reason] Reason for changing the channel's ratelimits
+   * @returns {Promise<TextChannel>}
+   */
+  setRateLimitPerUser(rateLimitPerUser, reason) {
+    return this.edit({ rateLimitPerUser }, reason);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1045,9 +1045,11 @@ declare module 'discord.js' {
 		public readonly members: Collection<Snowflake, GuildMember>;
 		public messages: MessageStore;
 		public nsfw: boolean;
+		public rateLimitPerUser: number;
 		public topic: string;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable, reason?: string }): Promise<Webhook>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
+		public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
 	}
 
@@ -1529,6 +1531,7 @@ declare module 'discord.js' {
 		bitrate?: number;
 		userLimit?: number;
 		parentID?: Snowflake;
+		rateLimitPerUser?: number;
 		lockPermissions?: boolean;
 		permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
 	};


### PR DESCRIPTION
* feat: Add TextChannel#rateLimitPerUser
Rename parameter in TextChannel#setRateLimitPerUser
feat: Add `rateLimitPerUser` param to ChannelData
fix: eslint

* docs: Updated typings

* fix: Requested changes

* fix: rateLimitPerUser being undefined when 0

When `rate_limit_per_user` is 0, the gateway does not send it (but REST does). When this is set to a non-zero number, this property starts to exist. Otherwise this will be `0`. Adding `|| 0` should do the trick changing `undefined` to `0`.

* fix: eslint

**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
