### PR TITLE
typings(ShardClientUtil): fix `id` property type (#3054)

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -951,7 +951,7 @@ declare module 'discord.js' {
 
 		public client: Client;
 		public readonly count: number;
-		public readonly id: number;
+		public readonly id: number | number[];
 		public mode: ShardingManagerMode;
 		public parentPort: any;
 		public broadcastEval(script: string): Promise<any[]>;


### PR DESCRIPTION
Ref: https://github.com/discordjs/discord.js/blob/d98d464d748a75e242b6e95a1308235bf4016e1b/src/sharding/ShardClientUtil.js#L50

**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
