### PR TITLE
Only reset sessionID when close code is 1000 or 4006 (#3213)

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -216,7 +216,7 @@ class WebSocketManager {
           return;
         }
 
-        if (event.code >= 1000 && event.code <= 2000) {
+        if (event.code === 1000 || event.code === 4006) {
           // Any event code in this range cannot be resumed.
           shard.sessionID = undefined;
         }


### PR DESCRIPTION
* Event code 1001 should not get its sessionID reset

* Reset sessionID when close code is 1000 or 4006

**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
