### PR TITLE
fix(READY): do not overwrite Client#user when reidentifying

### DIFF
--- a/src/client/websocket/handlers/READY.js
+++ b/src/client/websocket/handlers/READY.js
@@ -3,10 +3,14 @@
 let ClientUser;
 
 module.exports = (client, { d: data }, shard) => {
-  if (!ClientUser) ClientUser = require('../../../structures/ClientUser');
-  const clientUser = new ClientUser(client, data.user);
-  client.user = clientUser;
-  client.users.set(clientUser.id, clientUser);
+  if (client.user) {
+    client.user._patch(data.user);
+  } else {
+    if (!ClientUser) ClientUser = require('../../../structures/ClientUser');
+    const clientUser = new ClientUser(client, data.user);
+    client.user = clientUser;
+    client.users.set(clientUser.id, clientUser);
+  }
 
   for (const guild of data.guilds) {
     guild.shardID = shard.id;


### PR DESCRIPTION
See #3216, this commit attempts to fix losing ClientUser#_typing, which results in no longer being able to clear typing intervals

**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
