### PR TITLE
fix(GuildMember): do not create a channel key when editing

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -271,10 +271,11 @@ class GuildMember extends Base {
         throw new Error('GUILD_VOICE_CHANNEL_RESOLVE');
       }
       data.channel_id = data.channel.id;
+      data.channel = undefined;
     } else if (data.channel === null) {
       data.channel_id = null;
+      data.channel = undefined;
     }
-    data.channel = undefined;
     if (data.roles) data.roles = data.roles.map(role => role instanceof Role ? role.id : role);
     let endpoint = this.client.api.guilds(this.guild.id);
     if (this.user.id === this.client.user.id) {


### PR DESCRIPTION
This is to not break GuildMember#setNickname for the current user

**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
