### PR TITLE
fix(WebSocketShard): key name in WebSocketShard#_send. (#5304)

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -17,7 +17,7 @@ const Invite = require('../structures/Invite');
 const VoiceRegion = require('../structures/VoiceRegion');
 const Webhook = require('../structures/Webhook');
 const Collection = require('../util/Collection');
-const { Events, DefaultOptions } = require('../util/Constants');
+const { Events, DefaultOptions, InviteScopes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const Intents = require('../util/Intents');
 const Permissions = require('../util/Permissions');
@@ -377,6 +377,7 @@ class Client extends BaseClient {
    * @property {PermissionResolvable} [permissions] Permissions to request
    * @property {GuildResolvable} [guild] Guild to preselect
    * @property {boolean} [disableGuildSelect] Whether to disable the guild selection
+   * @property {InviteScope[]} [additionalScopes] Whether any additional scopes should be requested
    */
 
   /**
@@ -416,6 +417,18 @@ class Client extends BaseClient {
       const guildID = this.guilds.resolveID(options.guild);
       if (!guildID) throw new TypeError('INVALID_TYPE', 'options.guild', 'GuildResolvable');
       query.set('guild_id', guildID);
+    }
+
+    if (options.additionalScopes) {
+      const scopes = options.additionalScopes;
+      if (!Array.isArray(scopes)) {
+        throw new TypeError('INVALID_TYPE', 'additionalScopes', 'Array of Invite Scopes', true);
+      }
+      const invalidScope = scopes.find(scope => !InviteScopes.includes(scope));
+      if (invalidScope) {
+        throw new TypeError('INVALID_ELEMENT', 'Array', 'additionalScopes', invalidScope);
+      }
+      query.set('scope', ['bot', ...scopes].join(' '));
     }
 
     return `${this.options.http.api}${this.api.oauth2.authorize}?${query}`;

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -648,7 +648,7 @@ class WebSocketShard extends EventEmitter {
   _send(data) {
     if (!this.connection || this.connection.readyState !== WebSocket.OPEN) {
       this.debug(`Tried to send packet '${JSON.stringify(data)}' but no WebSocket is available!`);
-      this.destroy({ close: 4000 });
+      this.destroy({ closeCode: 4000 });
       return;
     }
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -89,6 +89,7 @@ const Messages = {
   GUILD_UNCACHED_ME: 'The client user as a member of this guild is uncached.',
 
   INVALID_TYPE: (name, expected, an = false) => `Supplied ${name} is not a${an ? 'n' : ''} ${expected}.`,
+  INVALID_ELEMENT: (type, name, elem) => `Supplied ${type} ${name} includes an invalid element: ${elem}`,
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -376,6 +376,36 @@ exports.WSEvents = keyMirror([
 ]);
 
 /**
+ * A valid scope to request when generating an invite link.
+ * <warn>Scopes that require whitelist are not considered valid for this generator</warn>
+ * * `applications.builds.read`: allows reading build data for a users applications
+ * * `applications.commands`: allows this bot to create commands in the server
+ * * `applications.entitlements`: allows reading entitlements for a users applications
+ * * `applications.store.update`: allows reading and updating of store data for a users applications
+ * * `connections`: makes the endpoint for getting a users connections available
+ * * `email`: allows the `/users/@me` endpoint return with an email
+ * * `identify`: allows the `/users/@me` endpoint without an email
+ * * `guilds`: makes the `/users/@me/guilds` endpoint available for a user
+ * * `guilds.join`: allows the bot to join the user to any guild it is in using Guild#addMember
+ * * `gdm.join`: allows joining the user to a group dm
+ * * `webhook.incoming`: generates a webhook to a channel
+ * @typedef {string} InviteScope
+ */
+exports.InviteScopes = [
+  'applications.builds.read',
+  'applications.commands',
+  'applications.entitlements',
+  'applications.store.update',
+  'connections',
+  'email',
+  'identity',
+  'guilds',
+  'guilds.join',
+  'gdm.join',
+  'webhook.incoming',
+];
+
+/**
  * The type of a message, e.g. `DEFAULT`. Here are the available types:
  * * DEFAULT
  * * RECIPIENT_ADD

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -513,6 +513,7 @@ declare module 'discord.js' {
       SMALL: 1;
       BIG: 2;
     };
+    InviteScopes: InviteScope[];
     MessageTypes: MessageType[];
     SystemMessageTypes: SystemMessageType[];
     ActivityTypes: ActivityType[];
@@ -2824,6 +2825,7 @@ declare module 'discord.js' {
     permissions?: PermissionResolvable;
     guild?: GuildResolvable;
     disableGuildSelect?: boolean;
+    additionalScopes?: InviteScope[];
   }
 
   interface InviteOptions {
@@ -2835,6 +2837,19 @@ declare module 'discord.js' {
   }
 
   type InviteResolvable = string;
+
+  type InviteScope =
+    | 'applications.builds.read'
+    | 'applications.commands'
+    | 'applications.entitlements'
+    | 'applications.store.update'
+    | 'connections'
+    | 'email'
+    | 'identity'
+    | 'guilds'
+    | 'guilds.join'
+    | 'gdm.join'
+    | 'webhook.incoming';
 
   type GuildTemplateResolvable = string;
 


### PR DESCRIPTION
I just changed an incorrect key name that was introduced in Pull Request #3722. When destroying the websocket from the WebSocketShard#_send method it's using `close` as the key name instead of `closeCode`

**Please describe the changes this PR makes and why it should be merged:**



**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
